### PR TITLE
Fix the Hello example in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Afterwards, the tests can be executed with:
    
 A simple Hello World program is executed with:
 
-    ./som.sh -cp Smalltalk Examples/Hello/Hello.som
+    ./som.sh -cp Smalltalk Examples/Hello.som
 
 The debug version of CSOM can be built using the `debug` target:
 


### PR DESCRIPTION
The Hello example in the README.md has an extra /Hello in the path
