### PR TITLE
Fix 2 crashes seen while running benchmarks

### DIFF
--- a/src/vm/Universe.c
+++ b/src/vm/Universe.c
@@ -273,6 +273,8 @@ const char** Universe_handle_arguments(
 
                 // guaranteed not to be used/referenced any more
                 internal_free(ext_path_tokens);
+            } else {
+                argv[i] = strdup(argv[i]);
             }
             // will not be referenced, because copied
             SEND(tmp_string, free);

--- a/src/vmobjects/VMString.c
+++ b/src/vmobjects/VMString.c
@@ -54,7 +54,7 @@ pVMString VMString_new(const char* restrict chars) {
  */
 void _VMString_init(void* _self, ...) {
     pVMString self = (pVMString)_self;
-    SUPER(VMObject, self, init, 1);
+    SUPER(VMObject, self, init, 0);
     
     va_list args; 
     va_start(args, _self);

--- a/src/vmobjects/VMSymbol.c
+++ b/src/vmobjects/VMSymbol.c
@@ -56,7 +56,7 @@ pVMSymbol VMSymbol_new(const char* restrict string) {
  */
 void _VMSymbol_init(void* _self, ...) {
     pVMSymbol self = (pVMSymbol)_self;    
-    SUPER(VMObject, self, init, 1);
+    SUPER(VMObject, self, init, 0);
     
     va_list args;
     va_start(args, _self);


### PR DESCRIPTION
- crash on shutdown freeing VM arguments
- crash during GC when attempting to mark  char data for String/Symbol
