### PR TITLE
Fix class loading and class field issues

### DIFF
--- a/CSOM.xcodeproj/project.pbxproj
+++ b/CSOM.xcodeproj/project.pbxproj
@@ -230,7 +230,7 @@
 		F6F205680C7DB2B40074678D /* Block.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Block.h; path = src/primitives/Block.h; sourceTree = SOURCE_ROOT; };
 		F6F205690C7DB2B40074678D /* Class.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = Class.c; path = src/primitives/Class.c; sourceTree = SOURCE_ROOT; };
 		F6F2056A0C7DB2B40074678D /* Class.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Class.h; path = src/primitives/Class.h; sourceTree = SOURCE_ROOT; };
-		F6F2056B0C7DB2B40074678D /* Core.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = Core.c; path = src/primitives/Core.c; sourceTree = SOURCE_ROOT; };
+		F6F2056B0C7DB2B40074678D /* Core.c */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.c; name = Core.c; path = src/primitives/Core.c; sourceTree = SOURCE_ROOT; tabWidth = 4; };
 		F6F2056C0C7DB2B40074678D /* Double.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = Double.c; path = src/primitives/Double.c; sourceTree = SOURCE_ROOT; };
 		F6F2056D0C7DB2B40074678D /* Double.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Double.h; path = src/primitives/Double.h; sourceTree = SOURCE_ROOT; };
 		F6F205700C7DB2B40074678D /* Integer.c */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.c; name = Integer.c; path = src/primitives/Integer.c; sourceTree = SOURCE_ROOT; tabWidth = 4; };

--- a/som.sh
+++ b/som.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-./CSOM "$@"
+SCRIPT_PATH=`dirname $0`
+exec ${SCRIPT_PATH}/CSOM "$@"

--- a/src/compiler/BytecodeGeneration.c
+++ b/src/compiler/BytecodeGeneration.c
@@ -72,12 +72,12 @@ void emit_DUP(method_generation_context* mgenc) {
 }
 
 
-void emit_PUSH_LOCAL(method_generation_context* mgenc, int idx, int ctx) {
+void emit_PUSH_LOCAL(method_generation_context* mgenc, size_t idx, size_t ctx) {
     EMIT3(BC_PUSH_LOCAL, idx, ctx);
 }
 
 
-void emit_PUSH_ARGUMENT(method_generation_context* mgenc, int idx, int ctx) {
+void emit_PUSH_ARGUMENT(method_generation_context* mgenc, size_t idx, size_t ctx) {
     EMIT3(BC_PUSH_ARGUMENT, idx, ctx);
 }
 
@@ -116,12 +116,12 @@ void emit_POP(method_generation_context* mgenc) {
 }
 
 
-void emit_POP_LOCAL(method_generation_context* mgenc, int idx, int ctx) {
+void emit_POP_LOCAL(method_generation_context* mgenc, size_t idx, size_t ctx) {
     EMIT3(BC_POP_LOCAL, idx, ctx);
 }
 
 
-void emit_POP_ARGUMENT(method_generation_context* mgenc, int idx, int ctx) {
+void emit_POP_ARGUMENT(method_generation_context* mgenc, size_t idx, size_t ctx) {
     EMIT3(BC_POP_ARGUMENT, idx, ctx);
 }
 

--- a/src/compiler/BytecodeGeneration.h
+++ b/src/compiler/BytecodeGeneration.h
@@ -39,16 +39,16 @@ THE SOFTWARE.
 
 void emit_HALT(method_generation_context* mgenc);
 void emit_DUP(method_generation_context* mgenc);
-void emit_PUSH_LOCAL(method_generation_context* mgenc, int idx, int ctx);
-void emit_PUSH_ARGUMENT(method_generation_context* mgenc, int idx, int ctx);
+void emit_PUSH_LOCAL(method_generation_context* mgenc, size_t idx, size_t ctx);
+void emit_PUSH_ARGUMENT(method_generation_context* mgenc, size_t idx, size_t ctx);
 void emit_PUSH_FIELD(method_generation_context* mgenc, pVMSymbol field);
 void emit_PUSH_BLOCK(method_generation_context* mgenc, pVMMethod block);
 void emit_PUSH_CONSTANT(method_generation_context* mgenc, pVMObject cst);
 void emit_PUSH_CONSTANT_String(method_generation_context* mgenc, pVMString str);
 void emit_PUSH_GLOBAL(method_generation_context* mgenc, pVMSymbol global);
 void emit_POP(method_generation_context* mgenc);
-void emit_POP_LOCAL(method_generation_context* mgenc, int idx, int ctx);
-void emit_POP_ARGUMENT(method_generation_context* mgenc, int idx, int ctx);
+void emit_POP_LOCAL(method_generation_context* mgenc, size_t idx, size_t ctx);
+void emit_POP_ARGUMENT(method_generation_context* mgenc, size_t idx, size_t ctx);
 void emit_POP_FIELD(method_generation_context* mgenc, pVMSymbol field);
 void emit_SEND(method_generation_context* mgenc, pVMSymbol msg);
 void emit_SUPER_SEND(method_generation_context* mgenc, pVMSymbol msg);

--- a/src/compiler/GenerationContexts.c
+++ b/src/compiler/GenerationContexts.c
@@ -112,8 +112,8 @@ int8_t method_genc_find_literal_index(
 bool method_genc_find_var(
     method_generation_context* mgenc,
     const char* var,
-    int* index,
-    int* context,
+    size_t* index,
+    size_t* context,
     bool* is_argument
 ) {
     // Searching proceeds as follows:

--- a/src/compiler/GenerationContexts.h
+++ b/src/compiler/GenerationContexts.h
@@ -81,8 +81,8 @@ int8_t  method_genc_find_literal_index(
 bool    method_genc_find_var(
     method_generation_context* mgenc,
     const char* var,
-    int* index,
-    int* context,
+    size_t* index,
+    size_t* context,
     bool* is_argument
 );
 bool    method_genc_find_field(method_generation_context* mgenc,

--- a/src/compiler/Parser.c
+++ b/src/compiler/Parser.c
@@ -342,8 +342,8 @@ void gen_push_variable(method_generation_context* mgenc, const char* var) {
     // is done by examining all available lexical contexts, starting with the
     // innermost (i.e., the one represented by mgenc).
     
-    int index = 0;
-    int context = 0;
+    size_t index = 0;
+    size_t context = 0;
     bool is_argument = false;
     if(method_genc_find_var(mgenc, var, &index, &context, &is_argument))
         if(is_argument)
@@ -368,8 +368,8 @@ void gen_pop_variable(method_generation_context* mgenc, const char* var) {
     // is done by examining all available lexical contexts, starting with the
     // innermost (i.e., the one represented by mgenc).
     
-    int index = 0;
-    int context = 0;
+    size_t index = 0;
+    size_t context = 0;
     bool is_argument = false;
     if(method_genc_find_var(mgenc, var, &index, &context, &is_argument))
         if(is_argument)

--- a/src/compiler/Parser.c
+++ b/src/compiler/Parser.c
@@ -474,10 +474,26 @@ void superclass(Lexer* l, class_generation_context* cgenc) {
         class_genc_set_class_fields_of_super(cgenc, SEND(SEND(super_class, get_class), get_instance_fields));
     } else {
         // we hardcode here the field names for Class
-        // since Object class superclass = Class
+        // SOM doesn't make them accessible normally anymore.
+        // On the language level, we only have the primitives.
+        // But to keep the implementation simple and allow classes to have
+        // fields, we add them back in here.
+
+        // We do this when the super_name is nil, because that means the class
+        // is Object, and we want to add the fields there on the class-side
+        // since Object class superclass = Class.
         // We avoid here any kind of dynamic solution to avoid further complexity.
         // However, that makes it static, it is going to make it harder to
         // change the definition of Class and Object
+
+        // There are exactly 4 fields
+        Universe_assert(4 == SIZE_DIFF_VMOBJECT(VMClass));
+
+        const char* field_names[] = {
+            "superClass", "name", "instanceFields", "instanceInvokables"};
+
+        pVMArray class_fields = Universe_new_array_from_argv(4, field_names);
+        class_genc_set_class_fields_of_super(cgenc, class_fields);
     }
 }
 

--- a/src/memory/gc.c
+++ b/src/memory/gc.c
@@ -176,7 +176,7 @@ void gc_mark_reachable_objects() {
 void gc_mark_object(void* _self) {
     pVMObject self = (pVMObject) _self;
     if (   ((void*) self >= (void*)  object_space) 
-        && ((void*) self <= (void*) (object_space + OBJECT_SPACE_SIZE))) 
+        && ((void*) self <= (void*) ((intptr_t) object_space + OBJECT_SPACE_SIZE)))
     {
         if (self->gc_field != 1) {
             // mark self before recursively marking contained references
@@ -241,7 +241,7 @@ void gc_show_memory() {
             object_aligner = 0;
         }
         pointer = (void*)((intptr_t)pointer + object_size);
-    } while ((void*)pointer < (void*)(object_space + OBJECT_SPACE_SIZE));    
+    } while ((void*)pointer < (void*)((intptr_t) object_space + OBJECT_SPACE_SIZE));
 }
 
 
@@ -312,7 +312,7 @@ void gc_collect() {
         // set the pointer to the next object in the heap
         pointer = (void*)((intptr_t)pointer + object_size);
 
-    } while ((void*)pointer < (void*)(object_space + OBJECT_SPACE_SIZE));
+    } while ((void*)pointer < (void*)((intptr_t)object_space + OBJECT_SPACE_SIZE));
 
     // combine free_entries, which are next to each other
     gc_merge_free_spaces();
@@ -431,7 +431,7 @@ void* gc_allocate_object(size_t size) {
 void gc_free(void* ptr) {
     // do nothing when called for an object inside the object_space
     if ((   ptr < (void*)  object_space) 
-        || (ptr >= (void*) (object_space + OBJECT_SPACE_SIZE))) 
+        || (ptr >= (void*) ((intptr_t)object_space + OBJECT_SPACE_SIZE))) 
     {
         internal_free(ptr);
     }

--- a/src/misc/List.c
+++ b/src/misc/List.c
@@ -39,9 +39,9 @@ void   _List_deep_free(void* _self);
 void   _List_addAll(void* _self, pList list);
 
 void   _List_clear(void* _self);
-int    _List_indexOf(void* _self, void* ptr);
-int    _List_size(void* _self);
-void*  _List_get(void* _self, int index);
+size_t _List_indexOf(void* _self, void* ptr);
+size_t _List_size(void* _self);
+void*  _List_get(void* _self, size_t index);
 
 void   _List_init(void* _self, ...);
 
@@ -208,33 +208,33 @@ void _List_clear(void* _self) {
 }
 
 
-int _List_indexOf(void* _self, void* ptr) {
+size_t _List_indexOf(void* _self, void* ptr) {
     pList self = (pList)_self;
     pListElem elem = self->head;
-    for(int result = 0; elem; result++, elem = elem->next)
+    for(size_t result = 0; elem; result++, elem = elem->next)
         if(elem->data == ptr)
             return result;
     return -1;
 }
 
 
-int _List_indexOfCString(void* _self, const char* cstring) {
+size_t _List_indexOfCString(void* _self, const char* cstring) {
     pList self = (pList)_self;
     pListElem elem = self->head;
-    for(int result = 0; elem; result++, elem = elem->next)
+    for(size_t result = 0; elem; result++, elem = elem->next)
         if(strcmp(cstring, SEND((pString)elem->data, chars)) == 0)
             return result;
     return -1;
 }
 
 
-int _List_size(void* _self) {
+size_t _List_size(void* _self) {
     pList self = (pList)_self;
     return self->size;
 }
 
 
-void* _List_get(void* _self, int index) {
+void* _List_get(void* _self, size_t index) {
     pList self = (pList)_self;
     pListElem elem = self->head;
     while(index-- && elem)

--- a/src/misc/List.h
+++ b/src/misc/List.h
@@ -45,10 +45,10 @@ VTABLE(List) {
     void  (*addAll)(void*, pList list); \
     void  (*clear)(void*); \
     void  (*deep_free)(void*); \
-    int   (*indexOf)(void*, void* ptr); \
-    int   (*indexOfCString)(void*, const char* str); \
-    int   (*size)(void*); \
-    void* (*get)(void*, int index)
+    size_t (*indexOf)(void*, void* ptr); \
+    size_t (*indexOfCString)(void*, const char* str); \
+    size_t (*size)(void*); \
+    void* (*get)(void*, size_t index)
     
     LIST_VTABLE_FORMAT;
 };
@@ -64,7 +64,7 @@ struct _List {
     VTABLE(List)* _vtable;
 #define LIST_FORMAT \
     OOOBJECT_FORMAT; \
-    int size; \
+    size_t size; \
     pListElem head; \
     pListElem last
 

--- a/src/primitives/Core.c
+++ b/src/primitives/Core.c
@@ -121,9 +121,14 @@ bool supports_class(const char* name) {
  * All work that needs to be done before the actual primitives are assigned
  * should be called from this function.
  */
+static bool initialized = false;
+
 void init_csp(void) {
     // Call init funcions.
-    __System_init();
-    __Integer_init();
+    if (!initialized) {
+        __System_init();
+        __Integer_init();
+        initialized = true;
+    }
 }
 

--- a/src/vm/Universe.c
+++ b/src/vm/Universe.c
@@ -513,11 +513,12 @@ pVMArray Universe_new_array(int64_t size) {
 
 pVMArray Universe_new_array_list(pList list) {
     // Allocate a new array with the same length as the list
-    pVMArray result = Universe_new_array(SEND(list, size));
+    size_t size = SEND(list, size);
+    pVMArray result = Universe_new_array(size);
     
     if(result) {
         // Copy all elements from the list into the array
-        for(int i = 0; i < SEND(list, size); i++) {
+        for(size_t i = 0; i < size; i++) {
             pVMObject elem =  (pVMObject)SEND(list, get, i);
             SEND(result, set_indexable_field, i, elem);
         }

--- a/src/vm/Universe.c
+++ b/src/vm/Universe.c
@@ -768,7 +768,7 @@ pVMClass Universe_get_block_class_with_args(int64_t number_of_arguments) {
     
     // Lookup the specific block class in the dictionary of globals and return
     // it
-    if(Universe_has_global(name)) 
+    if(Universe_has_global(name))
         return (pVMClass)Universe_get_global(name);
 
     // Get the block class for blocks with the given number of arguments
@@ -802,6 +802,10 @@ pVMClass Universe_load_class(pVMSymbol name) {
     // Load primitives (if necessary) and return the resulting class
     if (SEND(result, has_primitives) || SEND(result->class, has_primitives)) 
         SEND(result, load_primitives, class_path, cp_count);
+
+    // Insert the class into the dictionary of globals
+    Universe_set_global(name, (pVMObject)result);
+
     return result;
 }
 

--- a/src/vmobjects/VMMethod.c
+++ b/src/vmobjects/VMMethod.c
@@ -74,8 +74,8 @@ pVMMethod VMMethod_new(size_t number_of_bytecodes, size_t number_of_constants,
 
 pVMMethod VMMethod_assemble(method_generation_context* mgenc) {
     // create a method instance with the given number of bytecodes and literals
-    int num_literals = SEND(mgenc->literals, size);
-    int num_locals = SEND(mgenc->locals, size);
+    size_t num_literals = SEND(mgenc->literals, size);
+    size_t num_locals = SEND(mgenc->locals, size);
 
     pVMMethod meth = Universe_new_method(mgenc->signature, mgenc->bp,
         SEND(mgenc->literals, size), num_locals,

--- a/tests/BasicInterpreterTests.c
+++ b/tests/BasicInterpreterTests.c
@@ -30,44 +30,47 @@ static const double dbl375 = 3.75;
 
 static const Test tests[] = {
 //    {"Self", "assignSuper", 42, ProgramDefinitionError.class},
+//    {"Self", "assignSelf", 42, ProgramDefinitionError.class},
 
     {"MethodCall", "test", (void*) 42, INTEGER},
     {"MethodCall", "test2", (void*) 42, INTEGER},
 
-    {"NonLocalReturn", "test", "NonLocalReturn", CLASS},
     {"NonLocalReturn", "test1", (void*) 42, INTEGER},
     {"NonLocalReturn", "test2", (void*) 43, INTEGER},
     {"NonLocalReturn", "test3", (void*)  3, INTEGER},
     {"NonLocalReturn", "test4", (void*) 42, INTEGER},
     {"NonLocalReturn", "test5", (void*) 22, INTEGER},
 
-    {"Blocks", "arg1", (void*) 42, INTEGER},
-    {"Blocks", "arg2", (void*) 77, INTEGER},
-    {"Blocks", "argAndLocal",   (void*) 8, INTEGER},
-    {"Blocks", "argAndContext", (void*) 8, INTEGER},
+    {"Blocks", "testArg1", (void*) 42, INTEGER},
+    {"Blocks", "testArg2", (void*) 77, INTEGER},
+    {"Blocks", "testArgAndLocal",   (void*) 8, INTEGER},
+    {"Blocks", "testArgAndContext", (void*) 8, INTEGER},
 
-    {"Return", "returnSelf", "Return", CLASS},
-    {"Return", "returnSelfImplicitly", "Return", CLASS},
-    {"Return", "noReturnReturnsSelf", "Return", CLASS},
-    {"Return", "blockReturnsImplicitlyLastValue", (void*) 4, INTEGER},
+    {"Return", "testReturnSelf", "Return", CLASS},
+    {"Return", "testReturnSelfImplicitly", "Return", CLASS},
+    {"Return", "testNoReturnReturnsSelf", "Return", CLASS},
+    {"Return", "testBlockReturnsImplicitlyLastValue", (void*) 4, INTEGER},
 
     {"IfTrueIfFalse", "test",  (void*) 42, INTEGER},
     {"IfTrueIfFalse", "test2", (void*) 33, INTEGER},
     {"IfTrueIfFalse", "test3", (void*)  4, INTEGER},
 
-    {"CompilerSimplification", "returnConstantSymbol", "constant", SYMBOL},
-    {"CompilerSimplification", "returnConstantInt", (void*) 42, INTEGER},
-    {"CompilerSimplification", "returnSelf", "CompilerSimplification", CLASS},
-    {"CompilerSimplification", "returnSelfImplicitly", "CompilerSimplification",
+    {"CompilerSimplification", "testReturnConstantSymbol", "constant", SYMBOL},
+    {"CompilerSimplification", "testReturnConstantInt", (void*) 42, INTEGER},
+    {"CompilerSimplification", "testReturnSelf", "CompilerSimplification", CLASS},
+    {"CompilerSimplification", "testReturnSelfImplicitly", "CompilerSimplification",
         CLASS},
     {"CompilerSimplification", "testReturnArgumentN", (void*) 55, INTEGER},
     {"CompilerSimplification", "testReturnArgumentA", (void*) 44, INTEGER},
     {"CompilerSimplification", "testSetField", "foo", SYMBOL},
     {"CompilerSimplification", "testGetField", (void*) 40, INTEGER},
 
+    {"Hash", "testHash", (void*) 444, INTEGER},
+
     {"Arrays", "testEmptyToInts", (void*) 3, INTEGER},
     {"Arrays", "testPutAllInt", (void*) 5, INTEGER},
     {"Arrays", "testPutAllNil", "Nil", CLASS},
+    {"Arrays", "testPutAllBlock", (void*) 3, INTEGER},
     {"Arrays", "testNewWithAll", (void*) 1, INTEGER},
 
     {"BlockInlining", "testNoInlining", (void*) 1, INTEGER},
@@ -89,10 +92,14 @@ static const Test tests[] = {
 
     {"BlockInlining", "testToDoNestDoNestIfTrue", (void*) 2, INTEGER},
 
-    {"NonLocalVars", "writeDifferentTypes", (void*) &dbl375, DOUBLE},
+    {"NonLocalVars", "testWriteDifferentTypes", (void*) &dbl375, DOUBLE},
+
+    {"ObjectCreation", "test", (void*) 1000000, INTEGER},
 
     {"Regressions", "testSymbolEquality", (void*) 1, INTEGER},
     {"Regressions", "testSymbolReferenceEquality", (void*) 1, INTEGER},
+
+    {"NumberOfTests", "numberOfTests", (void*) 51, INTEGER},
 
     {NULL}
 };


### PR DESCRIPTION
This fixes class loading, which would load e.g. `Boolean` multiple times.

This also sets the fields for Class so that class fields do not corrupt the heap.
The implementation strategy in CSOM actually means there are some visible artifacts as a different set of visible fields via reflection.

And a few other minor improvements.