### PR TITLE
Allow up to 150MB to be used by emscripten

### DIFF
--- a/build/unix.make
+++ b/build/unix.make
@@ -142,7 +142,7 @@ profiling: all
 
 # emscripten : DBG_FLAGS=-g
 emscripten : EMBED_FILES+=--embed-file Smalltalk --embed-file Examples --embed-file TestSuite
-emscripten : EXP_FN=-s EXPORTED_FUNCTIONS="['_strcmp']" -s ENVIRONMENT=node -s EXPORT_ALL=1 -s LINKABLE=1 -s WASM=1 -s EXIT_RUNTIME=1
+emscripten : EXP_FN=-s EXPORTED_FUNCTIONS="['_strcmp']" -s ENVIRONMENT=node -s EXPORT_ALL=1 -s LINKABLE=1 -s WASM=1 -s EXIT_RUNTIME=1 -s TOTAL_MEMORY=150MB
 emscripten : MAIN_MODULE=-s MAIN_MODULE=1 $(EMBED_FILES) $(EXP_FN)
 emscripten : SIDE_MODULE=-s SIDE_MODULE=1 $(EXP_FN)
 emscripten : CC=emcc


### PR DESCRIPTION
150MB is for a 128MB heap size and a little head room, I hope this is sufficient for the AreWeFastYet benchmarks.