### PR TITLE
Setup ReBenchDB for continuous performance tracking

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,16 @@
+stages:
+  - build-test-benchmark
+
+variables:
+  PYTHONUNBUFFERED: "true"
+
+before_script:
+  - git submodule update --init
+
+build_test_benchmark_job:
+  stage: build-test-benchmark
+  tags: [benchmarks, infinity]
+  script:
+    - ARCH=64bit make
+    - ARCH=64bit make test
+    - rebench --without-nice --experiment="CI Benchmark Run Pipeline ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf CSOM

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "core-lib"]
 	path = core-lib
-	url = https://github.com/smarr/SOM.git
+	url = https://github.com/SOM-st/SOM.git

--- a/CSOM.xcodeproj/project.pbxproj
+++ b/CSOM.xcodeproj/project.pbxproj
@@ -182,7 +182,7 @@
 		F6F204050C7DA4310074678D /* Interpreter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Interpreter.h; sourceTree = "<group>"; };
 		F6F204080C7DA4310074678D /* gc.c */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.c; name = gc.c; path = src/memory/gc.c; sourceTree = SOURCE_ROOT; tabWidth = 4; };
 		F6F204090C7DA4310074678D /* gc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = gc.h; path = src/memory/gc.h; sourceTree = SOURCE_ROOT; };
-		F6F2040B0C7DA4310074678D /* debug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = debug.h; path = src/misc/debug.h; sourceTree = SOURCE_ROOT; };
+		F6F2040B0C7DA4310074678D /* debug.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.h; name = debug.h; path = src/misc/debug.h; sourceTree = SOURCE_ROOT; tabWidth = 4; };
 		F6F2040C0C7DA4310074678D /* defs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = defs.h; path = src/misc/defs.h; sourceTree = SOURCE_ROOT; };
 		F6F2040D0C7DA4310074678D /* Hashmap.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = Hashmap.c; path = src/misc/Hashmap.c; sourceTree = SOURCE_ROOT; };
 		F6F2040E0C7DA4310074678D /* Hashmap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Hashmap.h; path = src/misc/Hashmap.h; sourceTree = SOURCE_ROOT; };
@@ -241,7 +241,7 @@
 		F6F2057A0C7DB2B40074678D /* String.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = String.h; path = src/primitives/String.h; sourceTree = SOURCE_ROOT; };
 		F6F2057B0C7DB2B40074678D /* Symbol.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = Symbol.c; path = src/primitives/Symbol.c; sourceTree = SOURCE_ROOT; };
 		F6F2057C0C7DB2B40074678D /* Symbol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Symbol.h; path = src/primitives/Symbol.h; sourceTree = SOURCE_ROOT; };
-		F6F2057D0C7DB2B40074678D /* System.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = System.c; path = src/primitives/System.c; sourceTree = SOURCE_ROOT; };
+		F6F2057D0C7DB2B40074678D /* System.c */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.c; name = System.c; path = src/primitives/System.c; sourceTree = SOURCE_ROOT; tabWidth = 4; };
 		F6F2057E0C7DB2B40074678D /* System.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = System.h; path = src/primitives/System.h; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
@@ -586,6 +586,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 1;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* CSOM */;

--- a/rebench.conf
+++ b/rebench.conf
@@ -21,12 +21,12 @@ benchmark_suites:
         command: &MACRO_CMD "-cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s 0 "
         iterations: 10
         benchmarks:
-            - Richards:     {extra_args: "1"}
+            - Richards:     {extra_args: 1}
             - DeltaBlue:    {extra_args: 50}
             - NBody:        {extra_args: 500}
-            # - Json:         {extra_args: "80"} #TODO: crashes currently
-            # - GraphSearch:  {extra_args: 1}   # TODO: needs a problem that can be solved by CSOM
-            #- PageRank:     {extra_args: "1400"} # not supported by SOM's bytecode set
+            - JsonSmall:    {extra_args: 1}
+            - GraphSearch:  {extra_args: 4}
+            - PageRank:     {extra_args: 40}
 
     micro:
         gauge_adapter: RebenchLog

--- a/rebench.conf
+++ b/rebench.conf
@@ -1,0 +1,70 @@
+# -*- mode: yaml -*-
+# Config file for ReBench
+default_experiment: all
+default_data_file: 'rebench.data'
+
+reporting:
+    # Benchmark results will be reported to ReBenchDB
+    rebenchdb:
+        # this url needs to point to the API endpoint
+        db_url: https://rebench.stefan-marr.de/rebenchdb/results
+        repo_url: https://github.com/smarr/CSOM
+        record_all: true # make sure everything is recorded
+        project_name: CSOM
+
+runs:
+    max_invocation_time: 60
+
+benchmark_suites:
+    macro:
+        gauge_adapter: RebenchLog
+        command: &MACRO_CMD "-cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s 0 "
+        iterations: 10
+        benchmarks:
+            - Richards:     {extra_args: "1"}
+            - DeltaBlue:    {extra_args: 50}
+            - NBody:        {extra_args: 500}
+            # - Json:         {extra_args: "80"} #TODO: crashes currently
+            # - GraphSearch:  {extra_args: 1}   # TODO: needs a problem that can be solved by CSOM
+            #- PageRank:     {extra_args: "1400"} # not supported by SOM's bytecode set
+
+    micro:
+        gauge_adapter: RebenchLog
+        command: "-cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s 0 "
+        iterations: 10
+        benchmarks:
+            - Fannkuch:     {extra_args: 6}
+            - Fibonacci:    {extra_args: "3"}
+            - Dispatch:     {extra_args: 2}
+            - Bounce:       {extra_args: "2"}
+            - Loop:         {extra_args: 5}
+            - Permute:      {extra_args: "3"}
+            - Queens:       {extra_args: "2"}
+            - List:         {extra_args: "2"}
+            - Recurse:      {extra_args: "3"}
+            - Storage:      {extra_args: 1}
+            - Sieve:        {extra_args: 4}
+            - BubbleSort:   {extra_args: "3"}
+            - QuickSort:    {extra_args: 1}
+            - Sum:          {extra_args: 2}
+            - Towers:       {extra_args: "2"}
+            - TreeSort:     {extra_args: "1"}
+            - IntegerLoop:  {extra_args: 2}
+            - FieldLoop:    {extra_args: 1}
+            - WhileLoop:    {extra_args: 10}
+            - Mandelbrot:   {extra_args: 30}
+
+executors:
+    CSOM:
+        path: .
+        executable: CSOM
+        
+# define the benchmarks to be executed for a re-executable benchmark run
+experiments:
+    CSOM:
+        description: All benchmarks on CSOM
+        suites:
+            - micro
+            - macro
+        executions:
+            - CSOM

--- a/src/compiler/Lexer.c
+++ b/src/compiler/Lexer.c
@@ -196,6 +196,10 @@ void lexString(Lexer* l) {
     if (_BC == '\n') {
       l->line_num += 1;
     }
+    if (t >= l->text + BUFSIZ) {
+      debug_error("%s:%d: String too long. Doesn't fit into parse buffer.", l->file_name, l->line_num);
+      exit(ERR_FAIL);
+    }
     lexStringChar(l, &t);
     while (EOB) {
       if (fillbuffer(l) == -1) {

--- a/src/memory/gc.c
+++ b/src/memory/gc.c
@@ -135,8 +135,9 @@ void reset_alloc_stat(void);
 void gc_set_heap_size(uint32_t heap_size) {
     // this can only be done before the heap is initialised - afterwards, it
     // yields an error message and terminates the VM
-    if(object_space != NULL)
+    if (object_space != NULL) {
         Universe_error_exit("attempt to change heap size after initialisation");
+    }
     OBJECT_SPACE_SIZE = 1024 * 1024 * heap_size;
 }
 
@@ -387,16 +388,14 @@ void* gc_allocate(size_t size) {
             } else {
                 before_entry->next = replace_entry;
             }
-        }  else { 
+        } else {
             // no space was left
             // running the GC here will most certainly result in data loss!
             fprintf(stderr,"Not enough heap! Data loss is possible\n");
             fprintf(stderr, "FREE-Size: %zd, uninterruptable_counter: %d\n",
                 size_of_free_heap, uninterruptable_counter);
             
-            gc_collect();
-            //fulfill initial request
-            result = gc_allocate(size);
+            exit(ERR_FAIL);
         }
     }
            

--- a/src/misc/debug.h
+++ b/src/misc/debug.h
@@ -36,7 +36,8 @@ THE SOFTWARE.
     va_list ap; \
     va_start(ap, (x)); \
     (void)vfprintf((f), (x), ap); \
-    va_end(ap)
+    va_end(ap); \
+    fflush(f)
 
 
 static inline void debug_print(const char* fmt, ...) {
@@ -53,7 +54,8 @@ static inline void debug_prefix(const char* prefix) {
     va_list ap; \
     va_start(ap, (x)); \
     (void)vfprintf(stderr, (x), ap); \
-    va_end(ap)
+    va_end(ap); \
+    fflush(stderr)
 
 
 static inline void debug_info(const char* fmt, ...) {

--- a/src/primitives/System.c
+++ b/src/primitives/System.c
@@ -94,11 +94,13 @@ void  _System_exit_(pVMObject object, pVMFrame frame) {
 void  _System_printString_(pVMObject object, pVMFrame frame) {
     pVMString arg = (pVMString)SEND(frame, pop);
     printf("%s", SEND(arg, get_chars));
+    fflush(stdout);
 }
 
 
 void  _System_printNewline(pVMObject object, pVMFrame frame) {
-    printf("\n");    
+    printf("\n");
+    fflush(stdout);
 }
 
 

--- a/tests/BasicInterpreterTests.c
+++ b/tests/BasicInterpreterTests.c
@@ -99,7 +99,9 @@ static const Test tests[] = {
     {"Regressions", "testSymbolEquality", (void*) 1, INTEGER},
     {"Regressions", "testSymbolReferenceEquality", (void*) 1, INTEGER},
 
-    {"NumberOfTests", "numberOfTests", (void*) 51, INTEGER},
+    {"BinaryOperation", "test", (void*) 11, INTEGER},
+
+    {"NumberOfTests", "numberOfTests", (void*) 52, INTEGER},
 
     {NULL}
 };


### PR DESCRIPTION
This PR sets up GitLab (at Kent) to run the SOM benchmarks and report results to [ReBenchDB](https://rebench.stefan-marr.de/timeline/4).

The PR also includes somewhat unrelated but necessary changes:
 - fixing buffer overflows in the lexer
 - flushing output so that ReBench is guaranteed to pick it up correctly
 - make out of memory error fatal
 - update core-lib with fixes for benchmarks
