### PR TITLE
Fix semantics of empty blocks

### DIFF
--- a/src/compiler/GenerationContexts.c
+++ b/src/compiler/GenerationContexts.c
@@ -191,3 +191,7 @@ uint8_t method_genc_compute_stack_depth(method_generation_context* mgenc) {
     
     return max_depth;
 }
+
+bool method_genc_has_bytecodes(method_generation_context* mgenc) {
+    return mgenc->bp != 0;
+}

--- a/src/compiler/GenerationContexts.h
+++ b/src/compiler/GenerationContexts.h
@@ -88,5 +88,6 @@ bool    method_genc_find_var(
 bool    method_genc_find_field(method_generation_context* mgenc, pString field);
 uint8_t method_genc_compute_stack_depth(method_generation_context* mgenc);
 
+bool    method_genc_has_bytecodes(method_generation_context* mgenc);
 
 #endif // GENERATIONCONTEXTS_H_

--- a/tests/BasicInterpreterTests.c
+++ b/tests/BasicInterpreterTests.c
@@ -45,6 +45,9 @@ static const Test tests[] = {
     {"Blocks", "testArg2", (void*) 77, INTEGER},
     {"Blocks", "testArgAndLocal",   (void*) 8, INTEGER},
     {"Blocks", "testArgAndContext", (void*) 8, INTEGER},
+    {"Blocks", "testEmptyZeroArg", 1, INTEGER},
+    {"Blocks", "testEmptyOneArg", 1, INTEGER},
+    {"Blocks", "testEmptyTwoArg", 1, INTEGER},
 
     {"Return", "testReturnSelf", "Return", CLASS},
     {"Return", "testReturnSelfImplicitly", "Return", CLASS},
@@ -98,10 +101,12 @@ static const Test tests[] = {
 
     {"Regressions", "testSymbolEquality", (void*) 1, INTEGER},
     {"Regressions", "testSymbolReferenceEquality", (void*) 1, INTEGER},
+    {"Regressions", "testUninitializedLocal", 1, INTEGER},
+    {"Regressions", "testUninitializedLocalInBlock", 1, INTEGER},
 
     {"BinaryOperation", "test", (void*) 11, INTEGER},
 
-    {"NumberOfTests", "numberOfTests", (void*) 52, INTEGER},
+    {"NumberOfTests", "numberOfTests", (void*) 57, INTEGER},
 
     {NULL}
 };


### PR DESCRIPTION
This PR makes sure that empty blocks return `nil`, see: SOM-st/SOM#54.