### PR TITLE
Make 64bit default architecture

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,4 +13,4 @@ build_test_benchmark_job:
   script:
     - ARCH=64bit make
     - ARCH=64bit make test
-    - rebench --without-nice --experiment="CI Benchmark Run Pipeline ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf CSOM
+    - rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf CSOM

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@
 export ROOT_DIR	:=$(PWD)
 export BUILD_DIR:=$(ROOT_DIR)/build
 
-export ARCH?=32bit
+export ARCH?=64bit
 
 ifeq ($(ARCH),32bit)
   COMPILER_ARCH=-m32


### PR DESCRIPTION
This makes 64bit the default architecture. 32bit are more and more uncommon.